### PR TITLE
Adding a formatter breaks updates.

### DIFF
--- a/lib/binding.js
+++ b/lib/binding.js
@@ -121,7 +121,9 @@ Binding.prototype.unsubscribe = function(fn){
 
 Binding.prototype.change = function(fn) {
   fn.call(this);
-  var prop = this.el.getAttribute(this.name);
+  var calls = parse(this.el.getAttribute(this.name));
+  var prop = calls[0].name;
+
   var sub = this._subscribe || Binding.subscribe;
   sub(this.obj, prop, fn.bind(this));
 };

--- a/test/reactive.js
+++ b/test/reactive.js
@@ -171,4 +171,27 @@ describe('data-[attr]', function(){
     assert('/link/' + url == el.children[0].getAttribute('href'));
     assert(link.url == el.children[0].textContent);
   })
+
+  it('should update bindings with formatters', function(){
+    var el = domify('<div><p data-text="name | toUpper"></p></div>')[0];
+
+    function User(name) {
+      this.name = name;
+    }
+
+    Emitter(User.prototype);
+
+    var user = new User('Tobi');
+    var view = reactive(el, user, {
+      toUpper: function(text) {
+        return text.toUpperCase();
+      }
+    });
+
+    assert('TOBI' == el.children[0].textContent);
+
+    user.name = 'Loki';
+    user.emit('change name');
+    assert('LOKI' == el.children[0].textContent);
+  })
 })


### PR DESCRIPTION
Adding a formatter appears to prevent the DOM from updating. Had a poke around and I can't see the issue immediately.

The failing test:

``` js

  it('should update bindings with formatters', function(){
    var el = domify('<div><p data-text="name | toUpper"></p></div>')[0];

    function User(name) {
      this.name = name;
    }

    Emitter(User.prototype);

    var user = new User('Tobi');
    var view = reactive(el, user, {
      toUpper: function(text) {
        return text.toUpperCase()
      }
    });

    assert('TOBI' == el.children[0].textContent);

    user.name = 'Loki';
    user.emit('change name');
    assert('LOKI' == el.children[0].textContent);
  })

```
