### PR TITLE
Fix parameter type in docs for Reactive()

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,4 +1,3 @@
-
 /**
  * Module dependencies.
  */
@@ -73,7 +72,7 @@ exports.bind = function(name, fn){
  * Initialize a reactive template for `el` and `obj`.
  *
  * @param {Element} el
- * @param {Element} obj
+ * @param {Emitter} obj
  * @param {Object} options
  * @api public
  */


### PR DESCRIPTION
This seems to make more sense.
