### PR TITLE
Added basic two-way model binding for form fields

### DIFF
--- a/component.json
+++ b/component.json
@@ -10,7 +10,8 @@
     "visionmedia/debug": "*",
     "component/event": "0.1.0",
     "component/classes": "1.1.1",
-    "component/query": "*"
+    "component/query": "*",
+    "component/value": "*"
   },
   "development": {
     "component/assert": "*",

--- a/lib/bindings.js
+++ b/lib/bindings.js
@@ -4,6 +4,7 @@
 
 var classes = require('classes');
 var event = require('event');
+var value = require('value');
 
 /**
  * Attributes supported.
@@ -157,4 +158,36 @@ module.exports = function(bind){
       });
     });
   });
+
+  /**
+   * Two-way model binding
+   */
+
+  bind('data-field', function(el, attr, obj) {
+    var type = el.getAttribute('type');
+    var name = el.nodeName.toLowerCase();
+    event.bind(el, 'change', function(){
+      if(typeof obj.set === "function") {
+        obj.set(attr, value(el));
+      }
+      else if(typeof obj[attr] === "function") {
+        obj[attr](value(el));
+      }
+      else {
+        obj[attr] = value(el);
+      }
+    });
+    this.change(function(val){
+      if(name !== "input" && name !== "select") {
+        el.innerHTML = val;
+      }
+      else if(type === "radio") {
+        value(el, el.value === String(val));
+      }
+      else {
+        value(el, val);
+      }
+    });
+  });
+
 };


### PR DESCRIPTION
This allows inputs, selects and textareas to have two-way binding to a model. Supports basic model methods, `model.set(foo, bar)`,  `model.foo(bar)` and `model.foo = bar`.

This supports text inputs, radio buttons, checkboxes, selects and textareas. Leverages component/value for most of the hard work. 

Some of the logic could be pulled into component/value and the model setting method could possibly be set manually like subscribe and unsubscribe. Maybe `reactive.get` and `reactive.set`? 
