### PR TITLE
defer to views over models for interpolation

### DIFF
--- a/lib/attr-binding.js
+++ b/lib/attr-binding.js
@@ -54,10 +54,11 @@ AttrBinding.prototype.render = function(){
   var attr = this.attr;
   var text = this.text;
   var obj = this.view.obj;
+  var fns = this.view.fns;
   debug('render %s "%s"', attr.name, text);
   attr.value = utils.interpolate(text, function(prop, fn){
     return fn
-      ? fn(obj)
+      ? fn(obj, fns)
       : obj[prop];
   });
 };

--- a/lib/text-binding.js
+++ b/lib/text-binding.js
@@ -53,10 +53,11 @@ TextBinding.prototype.render = function(){
   var node = this.node;
   var text = this.text;
   var obj = this.view.obj;
+  var fns = this.view.fns;
   debug('render "%s"', text);
   node.data = utils.interpolate(text, function(prop, fn){
     return fn
-      ? fn(obj)
+      ? fn(obj, fns)
       : obj[prop];
   });
 };

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -96,11 +96,11 @@ exports.clean = function(str) {
 
 function compile(expr) {
   debug('compile `%s`', expr);
-  var re = /\.\w+|\w+ *\(|"[^"]*"|'[^']*'|\/([^/]+)\/|[a-zA-Z_]\w*/g;
+  var re = /\.\w+|\w+ *\([^\)]*\)|"[^"]*"|'[^']*'|\/([^/]+)\/|[a-zA-Z_]\w*/g;
   var p = props(expr);
 
   var body = expr.replace(re, function(_) {
-    if ('(' == _[_.length - 1]) return access(_);
+    if ('(' == _[_.length - 2]) return access(_);
     if (!~p.indexOf(_)) return _;
     return wrap(_);
   });
@@ -116,7 +116,9 @@ function compile(expr) {
  */
 
 function access(prop) {
-  return 'model.' + prop;
+  return '(view.' + prop.replace(/\([^\)]*\)/, '') +
+    ' ? view.' + prop +
+    ' : model.' + prop + ')';
 }
 
 /**
@@ -128,9 +130,13 @@ function access(prop) {
  */
 
 function wrap(prop) {
-  return '("function" == typeof model.' + prop +
-    ' ? model.' + prop + '()' +
-    ' : model.' + prop + ')';
+  return '("function" == typeof view.' + prop +
+    ' ? view.' + prop + '()' +
+    ' : view.hasOwnProperty("' + prop + '")' +
+      ' ? view.' + prop +
+      ' : "function" == typeof model.' + prop +
+        ' ? model.' + prop + '()' +
+        ' : model.' + prop + ')';
 }
 
 /**

--- a/test/text-interpolation.js
+++ b/test/text-interpolation.js
@@ -113,6 +113,36 @@ describe('text interpolation', function(){
     assert('name: Loki the Pet' == el.textContent);
   })
 
+  it('should defer to view before model in complex calls', function(){
+    var el = domify('<p>name: {casual ? first : first + " " + last}</p>');
+
+    var pet = {
+      casual: function(){ return false },
+      first: function(){ return 'Loki' },
+      last: function(){ return 'the Pet' }
+    };
+
+    var view = {
+      casual: function(){ return true }
+    }
+
+    reactive(el, pet, view);
+    assert('name: Loki' == el.textContent);
+  })
+
+  it('should support complex model method calls as properties', function(){
+    var el = domify('<p>name: {casual ? first : first + " " + last}</p>');
+
+    var pet = {
+      casual: function(){ return false },
+      first: function(){ return 'Loki' },
+      last: function(){ return 'the Pet' }
+    };
+
+    reactive(el, pet);
+    assert('name: Loki the Pet' == el.textContent);
+  })
+
   it('should support the root element', function(){
     var el = domify('<p>Hello {name}</a>')[0];
     var user = { name: 'Tobi' };


### PR DESCRIPTION
fixes #46

does the same type of check as `Binding#value` where it looks for `view` over `model`, and methods over properties.

there might be a cleaner way to write this, happy to iterate there.
