### PR TITLE
bind to append/replace last

### DIFF
--- a/lib/bindings.js
+++ b/lib/bindings.js
@@ -63,24 +63,6 @@ module.exports = function(bind){
     });
   });
 
-/**
- * Append child element.
- */
-
-  bind('data-append', function(el, name){
-    var other = this.value(name);
-    el.appendChild(other);
-  });
-
-/**
- * Replace element.
- */
-
-  bind('data-replace', function(el, name){
-    var other = this.value(name);
-    el.parentNode.replaceChild(other, el);
-  });
-
   /**
    * Show binding.
    */
@@ -149,12 +131,30 @@ module.exports = function(bind){
 
   events.forEach(function(name){
     bind('on-' + name, function(el, method){
-      var fns = this.view.fns
+      var fns = this.view.fns;
       event.bind(el, name, function(e){
         var fn = fns[method];
         if (!fn) throw new Error('method .' + method + '() missing');
         fns[method](e);
       });
     });
+  });
+
+  /**
+   * Append child element.
+   */
+
+  bind('data-append', function(el, name){
+    var other = this.value(name);
+    el.appendChild(other);
+  });
+
+  /**
+   * Replace element.
+   */
+
+  bind('data-replace', function(el, name){
+    var other = this.value(name);
+    el.parentNode.replaceChild(other, el);
   });
 };


### PR DESCRIPTION
this is a quick patch for #32, by performing the append/replace last we get around the events problem. there could still be other cases that get screwed (`replace`ing with a child that has `append`s or something) but this fixes a lot of them.

i wonder if the other could even be solved by just remove the reactive-specific attributes... dunno if that makes it too magic-y though. slash or if it should be fixed somehow else in the abstraction
