### PR TITLE
Added use method

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -100,7 +100,8 @@ exports.bind = function(name, fn){
  */
  
 exports.use = function(fn) {
-  return fn(exports.bind, exports.adapter);
+  fn(exports);
+  return this;
 };
 
 /**
@@ -260,7 +261,8 @@ Reactive.prototype.bind = function(name, fn) {
  */
 
 Reactive.prototype.use = function(fn) {
-  return fn(this);
+  fn(this);
+  return this;
 };
 
 // bundled bindings


### PR DESCRIPTION
For plugins/middleware etc. Just makes it a bit nicer to create additional functionality for reactive.

``` js
var reactive = require('reactive');
var form = require('reactive-form');
var json = require('reactive-json');

reactive
   .use(json)
   .use(form);
```
