### PR TITLE
View-specific Adapters

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -115,6 +115,7 @@ exports.use = function(fn) {
 
 function Reactive(el, model, view) {
   if (!(this instanceof Reactive)) return new Reactive(el, model, view);
+  this.adapter = exports.adapter;
   this.el = el;
   this.model = model;
   this.els = [];
@@ -133,7 +134,7 @@ function Reactive(el, model, view) {
  */
 
 Reactive.prototype.sub = function(prop, fn){
-  adapter.subscribe(this.model, prop, fn);
+  this.adapter.subscribe(this.model, prop, fn);
   return this;
 };
 
@@ -147,7 +148,7 @@ Reactive.prototype.sub = function(prop, fn){
  */
 
 Reactive.prototype.unsub = function(prop, fn){
-  adapter.unsubscribe(this.model, prop, fn);
+  this.adapter.unsubscribe(this.model, prop, fn);
   return this;
 };
 
@@ -161,7 +162,7 @@ Reactive.prototype.unsub = function(prop, fn){
  */
 
 Reactive.prototype.get = function(prop) {
-  return adapter.get(this.model, prop);
+  return this.adapter.get(this.model, prop);
 };
 
 /**
@@ -174,7 +175,7 @@ Reactive.prototype.get = function(prop) {
  */
 
 Reactive.prototype.set = function(prop, val) {
-  adapter.set(this.model, prop, val);
+  this.adapter.set(this.model, prop, val);
   return this;
 };
 


### PR DESCRIPTION
View-specific adapters. Pretty simple. Libraries can provide their own adapters:

``` js
var Observable = require('observable');
var view = reactive(el, model);
view.adapter = Observable.adapter;
```

Same interface for global reactive adapter so this still works

``` js
reactive.adapter = Observable.adapter;
```

To make it affect all Reactive instances. If we get that `use` pull request in, it will be cleaner:

``` js
reactive.use(observable.adapter);
```
