### PR TITLE
Added support for event arguments

### DIFF
--- a/component.json
+++ b/component.json
@@ -16,7 +16,8 @@
     "component/assert": "*",
     "component/domify": "1.0.0",
     "component/emitter": "1.0.0",
-    "component/clone": "0.1.0"
+    "component/clone": "0.1.0",
+    "adamsanderson/trigger-event": "*"
   },
   "scripts": [
     "lib/index.js",

--- a/lib/bindings.js
+++ b/lib/bindings.js
@@ -4,6 +4,7 @@
 
 var classes = require('classes');
 var event = require('event');
+var parse = require('format-parser');
 
 /**
  * Attributes supported.
@@ -150,11 +151,13 @@ module.exports = function(bind){
 
   events.forEach(function(name){
     bind('on-' + name, function(el, method){
-      var fns = this.view.fns
+      var fns = this.view.fns;
+      var call = parse(method)[0];
       event.bind(el, name, function(e){
-        var fn = fns[method];
+        var fn = fns[call.name];
+        call.args.unshift(e);
         if (!fn) throw new Error('method .' + method + '() missing');
-        fns[method](e);
+        fn.apply(this, call.args);
       });
     });
   });

--- a/test/bindings.js
+++ b/test/bindings.js
@@ -2,6 +2,7 @@
 var reactive = require('reactive');
 var domify = require('domify');
 var assert = require('assert');
+var trigger = require('trigger-event');
 
 describe('reactive.bind(name, fn)', function(){
   it('should define a new binding', function(done){
@@ -49,6 +50,19 @@ describe('Reactive#bind(name, fn)', function(){
       assert('UL' == el.nodeName);
       done();
     });
+  })
+
+  it('should support event arguments', function(done){
+    var el = domify('<span on-click="show:1,2,3"></span>');
+    var view = reactive(el, {}, {
+      show: function(e, one, two, three) {
+        assert("1" === one);
+        assert("2" === two);
+        assert("3" === three);
+        done();
+      }
+    });
+    trigger(el, 'click');
   })
 })
 


### PR DESCRIPTION
Small change that adds the format-parser to event values allowing us to pass arguments to events:

``` js
<a on-click="show:1,2,3"></a>
```

The function is passed the event and then the arguments `fn(event, arg1, arg2...)` I've had a few cases where this would save me needing to do the logic in JS. 
