### PR TITLE
Added ability to add global formatters

### DIFF
--- a/lib/binding.js
+++ b/lib/binding.js
@@ -106,8 +106,8 @@ Binding.prototype.formatted = function(fmt) {
   for (var i = 1; i < calls.length; ++i) {
     var call = calls[i];
     call.args.unshift(val);
-    var fn = this.fns[call.name];
-    val = fn.apply(this.fns, call.args);
+    var fn = this.view.formatter(call.name);
+    val = fn.apply(this.view, call.args);
   }
 
   return val;

--- a/lib/index.js
+++ b/lib/index.js
@@ -24,6 +24,12 @@ exports = module.exports = Reactive;
 exports.bindings = {};
 
 /**
+ * Formatters.
+ */
+
+exports.formatters = {};
+
+/**
  * Define subscription function.
  *
  * @param {Function} fn
@@ -94,20 +100,40 @@ exports.bind = function(name, fn){
 };
 
 /**
- * Initialize a reactive template for `el` and `obj`.
+ * Define a format `name`  with callback `fn(val)`
  *
- * @param {Element} el
- * @param {Element} obj
- * @param {Object} options
+ * @param  {String} name or object
+ * @param  {String|Object} name
+ * @param  {Function} fn
  * @api public
  */
 
-function Reactive(el, obj, options) {
-  if (!(this instanceof Reactive)) return new Reactive(el, obj, options);
+exports.format = function(name, fn){
+  if ('object' == typeof name) {
+    for (var key in name) {
+      exports.format(key, name[key]);
+    }
+    return;
+  }
+
+  exports.formatters[name] = fn;
+};
+
+/**
+ * Initialize a reactive template for `el` and `model`.
+ *
+ * @param {Element} el
+ * @param {Object} model
+ * @param {Object} view
+ * @api public
+ */
+
+function Reactive(el, model, view) {
+  if (!(this instanceof Reactive)) return new Reactive(el, model, view);
   this.el = el;
-  this.obj = obj;
+  this.obj = this.model = model;
   this.els = [];
-  this.fns = options || {}; // TODO: rename, this is awful
+  this.fns = this.view = view || {}; // TODO: rename, this is awful
   this.bindAll();
   this.bindInterpolation(this.el, []);
 }
@@ -240,6 +266,25 @@ Reactive.prototype.bind = function(name, fn) {
   for (var i = 0; i < els.length; i++) {
     var binding = new Binding(name, this, els[i], fn);
     binding.bind();
+  }
+};
+
+/**
+ * Get a formatter by name
+ * @param  {String} name
+ * @return {Function}
+ * @api private
+ */
+
+Reactive.prototype.formatter = function(name) {
+  if('function' == typeof this.view[name]) {
+    return this.view[name];
+  }
+  if('function' == typeof this.obj[name]) {
+    return this.obj[name];
+  }
+  if('function' == typeof exports.formatters[name]) {
+    return exports.formatters[name];
   }
 };
 

--- a/test/formatters.js
+++ b/test/formatters.js
@@ -1,0 +1,16 @@
+
+var Emitter = require('emitter');
+var reactive = require('reactive');
+var domify = require('domify');
+var assert = require('assert');
+
+describe('string formatters', function(){
+  it('should define a formatter', function(){
+    reactive.format('foo', function(){
+      return 'bar';
+    })
+    var el = domify('<p data-text="name | foo"></p>');
+    reactive(el, {});
+    assert( el.innerHTML === "bar" )
+  })
+})

--- a/test/index.html
+++ b/test/index.html
@@ -16,6 +16,7 @@
     <script src="attr-interpolation.js"></script>
     <script src="computed.js"></script>
     <script src="adapters.js"></script>
+    <script src="formatters.js"></script>
     <script>
       mocha.run();
     </script>


### PR DESCRIPTION
Works the same way bindings work:

``` js
reactive.format('mySweetDate', function(val){
   return moment(val).format('DD/MM/YYYY');
});
```

They are just normal formatters:

``` html
<span data-text="currentTime | mySweetDate"></span>
```

And reactive will still use the views formatter first if you need to override it on a view-by-view case:

``` js
reactive(el, {}, {
   mySweetDate: function(){
      return "doh!";
   }
});
```

Makes it really easy to reuse formatters across applications

``` js
var formatters = require('my-formatters');
var reactive = require('reactive');

reactive.use(formatters);
```

Tried to get local formatters working, but that would require a manual trigger of `reactive.bindAll` by the user.

``` js
var view = reactive(el, {});
view.format('data', someDataFunction);
view.bindAll();
```

Otherwise it will complain about the format method not existing. This would require changing the Reactive API.
