### PR TITLE
Iteration and nested reactive instances

### DIFF
--- a/component.json
+++ b/component.json
@@ -10,7 +10,8 @@
     "visionmedia/debug": "*",
     "component/event": "0.1.0",
     "component/classes": "1.1.1",
-    "component/query": "*"
+    "component/query": "*",
+    "anthonyshort/dom-walk": "*"
   },
   "development": {
     "component/assert": "*",

--- a/examples/iteration.html
+++ b/examples/iteration.html
@@ -1,0 +1,77 @@
+
+<style>
+  body {
+    padding: 50px;
+    font: 14px Helvetica, Arial;
+  }
+  label {
+    display: block;
+    clear: both;
+  }
+  .hide {
+    display: none;
+  }
+  .show {
+    display: block;
+  }
+</style>
+
+<script src="../build/build.js"></script>
+
+<h1>Iteration</h1>
+<p>Loop over all objects in an array:</p>
+
+<ul id="list" data-each="people < family">
+  <li>
+    {name}
+    <ul data-each="children">
+      <li>{name}</li>
+    </ul>
+    <span data-hide="children">They have no children</span>
+  </li>
+</ul>
+
+<script>
+  var reactive = require('reactive');
+  var Emitter = require('component-emitter');
+  var domify = require('component-domify');
+
+  var model = new Emitter();
+
+  model.people = [
+    {
+      name: "Tedd",
+      children: [{name:"one"},{name:"two"}]
+    },
+    {
+      name: "Marshal & Lily",
+      children: [{name:"one"}]
+    },
+    {
+      name: "Robin & Barney"
+    }
+  ];
+
+  reactive.bind('data-each', function(el, attr){
+    var template = domify(el.innerHTML);
+
+    this.change(function(){
+      el.innerHTML = "";
+      var items = this.value(attr);
+      if(!items) return;
+      items.forEach(function(item){
+        var itemEl = template.cloneNode(true);
+        reactive(itemEl, item).render();
+        el.appendChild(itemEl);
+      });
+    });
+
+    // This makes reactive skip parsing any
+    // child nodes passed this element
+    this.skip = true;
+  });
+
+  var view = reactive(document.querySelector('#list'), model);
+  view.render();
+
+</script>

--- a/lib/binding.js
+++ b/lib/binding.js
@@ -24,6 +24,7 @@ function Binding(name, reactive, el, fn) {
   this.view = reactive.view;
   this.el = el;
   this.fn = fn;
+  this.skip = false;
 }
 
 /**

--- a/lib/index.js
+++ b/lib/index.js
@@ -9,7 +9,7 @@ var debug = require('debug')('reactive');
 var bindings = require('./bindings');
 var Binding = require('./binding');
 var utils = require('./utils');
-var query = require('query');
+var walk = require('dom-walk');
 
 /**
  * Expose `Reactive`.
@@ -89,7 +89,6 @@ exports.bind = function(name, fn){
     }
     return;
   }
-
   exports.bindings[name] = fn;
 };
 
@@ -119,8 +118,8 @@ function Reactive(el, model, view) {
   this.model = model;
   this.els = [];
   this.view = view || {};
-  this.bindAll();
-  this.bindInterpolation(this.el, []);
+  this.bindings = {};
+  this.bind(exports.bindings);
 }
 
 /**
@@ -179,52 +178,6 @@ Reactive.prototype.set = function(prop, val) {
 };
 
 /**
- * Traverse and bind all interpolation within attributes and text.
- *
- * @param {Element} el
- * @api private
- */
-
-Reactive.prototype.bindInterpolation = function(el, els){
-
-  // element
-  if (el.nodeType == 1) {
-    for (var i = 0; i < el.attributes.length; i++) {
-      var attr = el.attributes[i];
-      if (utils.hasInterpolation(attr.value)) {
-        new AttrBinding(this, el, attr);
-      }
-    }
-  }
-
-  // text node
-  if (el.nodeType == 3) {
-    if (utils.hasInterpolation(el.data)) {
-      debug('bind text "%s"', el.data);
-      new TextBinding(this, el);
-    }
-  }
-
-  // walk nodes
-  for (var i = 0; i < el.childNodes.length; i++) {
-    var node = el.childNodes[i];
-    this.bindInterpolation(node, els);
-  }
-};
-
-/**
- * Apply all bindings.
- *
- * @api private
- */
-
-Reactive.prototype.bindAll = function() {
-  for (var name in exports.bindings) {
-    this.bind(name, exports.bindings[name]);
-  }
-};
-
-/**
  * Bind `name` to `fn`.
  *
  * @param {String|Object} name or object
@@ -239,19 +192,53 @@ Reactive.prototype.bind = function(name, fn) {
     }
     return;
   }
+  this.bindings[name] = fn;
+  return this;
+};
 
-  var els = query.all('[' + name + ']', this.el);
-  if (this.el.hasAttribute && this.el.hasAttribute(name)) {
-    els = [].slice.call(els);
-    els.unshift(this.el);
-  }
-  if (!els.length) return;
+/**
+ * Walk the DOM and render all bindings
+ * @param  {Function} [fn]
+ * @return {void}
+ * @api public
+ */
 
-  debug('bind [%s] (%d elements)', name, els.length);
-  for (var i = 0; i < els.length; i++) {
-    var binding = new Binding(name, this, els[i], fn);
-    binding.bind();
-  }
+Reactive.prototype.render = function(fn){
+  var self = this;
+  var bindings = this.bindings;
+
+  walk(this.el, function(el, next){
+
+    // element
+    if (el.nodeType == 1) {
+      var cont;
+
+      utils.attributes(el, function(attr){
+        if (utils.hasInterpolation(attr.value)) {
+          new AttrBinding(self, el, attr);
+        }
+        else if(bindings[attr.name]) {
+          var binding = new Binding(attr.name, self, el, bindings[attr.name]);
+          binding.bind();
+          if(binding.skip === true) {
+            cont = false;
+          }
+        }
+      });
+
+      return next(cont);
+    }
+
+    // text node
+    if (el.nodeType == 3) {
+      if (utils.hasInterpolation(el.data)) {
+        debug('bind text "%s"', el.data);
+        new TextBinding(self, el);
+      }
+    }
+
+    next();
+  }, fn);
 };
 
 /**

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -103,6 +103,19 @@ exports.call = function(model, view, prop){
 };
 
 /**
+ * Loop over all the attributes of an element
+ * @param  {Element}   el
+ * @param  {Function} fn
+ * @return {void}
+ */
+
+exports.attributes = function(el, fn) {
+  for (var i = 0; i < el.attributes.length; i++) {
+    fn(el.attributes[i]);
+  }
+};
+
+/**
  * Compile `expr` to a `Function`.
  *
  * @param {String} expr

--- a/test/bindings.js
+++ b/test/bindings.js
@@ -39,6 +39,8 @@ describe('Reactive#bind(name, fn)', function(){
       assert('LI' == el.nodeName);
       done();
     });
+
+    view.render();
   })
 
   it('should support root-level bindings', function(done){
@@ -49,6 +51,8 @@ describe('Reactive#bind(name, fn)', function(){
       assert('UL' == el.nodeName);
       done();
     });
+
+    view.render();
   })
 })
 
@@ -63,5 +67,7 @@ describe('Reactive#bind(obj)', function(){
         done();
       }
     });
+
+    view.render();
   })
 })


### PR DESCRIPTION
The major change here is that we're walking the DOM to bind attributes instead of running just a plain querySelector whenever a binding is added.  There are a couple of benefits:
- This allows for bindings to tell reactive to skip parsing its children 
- Iteration and nested instances are possible
- All bindings are rendered at once

Tests aren't passing yet because of an API change :)
## Iteration

I've included a simple iteration example. If the elements within the model are in fact models themselves, they will be able to emit changes and update the DOM themselves without re-rendering the entire list.

``` html
<div id="view">
  <h1>{name}</h1>
  <ul data-each="items">
    <li>{name}</li>
  </ul>
</div>
```

Using the old query method we can't tell reactive to stop trying to parse the bindings of items within an iteration. Reactive would replace the `{name}` within the iteration, which we don't want. Instead, we want reactive to go down the DOM tree and process the bindings on each element. If a binding tells reactive to skip the children, it will leave them alone. Now the `data-each` binding **can create nested reactive instances**.
## API changes

The downside to this is that we now to have to add all the bindings and then call a render method:

``` js
var view = reactive(el, model, view);
view.render();
```

Basically, you need to define all of your bindings before you call render or declare the bindings and run `render` again. But this shouldn't hurt too much:

``` js
reactive(el, model, view)
  .use(customBindings)
  .use(eventBindings)
  .render();
```
## Skipping Children

Skipping works by setting `this.skip` in the binding to `true`. This will tell reactive to skip and nodes within this element. This allows the bindings to control what happens inside of the sub-element effectively allowing us to create nested reactive instances.

``` js
reactive.bind('data-each', function(el, attr){
  this.skip = true;
});
```
