### PR TITLE
change hide to hidden and show to visible

### DIFF
--- a/lib/bindings.js
+++ b/lib/bindings.js
@@ -86,12 +86,12 @@ module.exports = function(reactive){
    * Show binding.
    */
 
-  reactive.bind('data-show', function(el, name){
+  reactive.bind('data-visible', function(el, name){
     this.change(function(){
       if (this.value(name)) {
-        classes(el).add('show').remove('hide');
+        classes(el).add('visible').remove('hidden');
       } else {
-        classes(el).remove('show').add('hide');
+        classes(el).remove('visible').add('hidden');
       }
     });
   });
@@ -100,12 +100,12 @@ module.exports = function(reactive){
    * Hide binding.
    */
 
-  reactive.bind('data-hide', function(el, name){
+  reactive.bind('data-hidden', function(el, name){
     this.change(function(){
       if (this.value(name)) {
-        classes(el).remove('show').add('hide');
+        classes(el).remove('visible').add('hidden');
       } else {
-        classes(el).add('show').remove('hide');
+        classes(el).add('visible').remove('hidden');
       }
     });
   });

--- a/test/computed.js
+++ b/test/computed.js
@@ -49,15 +49,15 @@ describe('computed properties', function(){
   })
 
   it('should work with .value() only', function(){
-    var el = domify('<p><em data-hide="removed < removed_at"></em></p>');
+    var el = domify('<p><em data-hidden="removed < removed_at"></em></p>');
     var user = new User('Tobi', 'Ferret');
     var view = reactive(el, user);
     var em = el.children[0];
 
-    assert('show' == em.className);
+    assert('visible' == em.className);
 
     user.removed_at = new Date;
     user.emit('change removed_at');
-    assert('hide' == em.className);
+    assert('hidden' == em.className);
   })
 })

--- a/test/reactive.js
+++ b/test/reactive.js
@@ -132,35 +132,35 @@ describe('data-html', function(){
   })
 })
 
-describe('data-show', function(){
-  it('should add .show when truthy', function(){
-    var el = domify('<div><p data-show="file">Has a file</p></div>');
+describe('data-visible', function(){
+  it('should add .visible when truthy', function(){
+    var el = domify('<div><p data-visible="file">Has a file</p></div>');
     var item = { file: 'some.png' };
     var view = reactive(el, item);
-    assert('show' == el.children[0].className);
+    assert('visible' == el.children[0].className);
   })
 
-  it('should remove .hide when truthy', function(){
-    var el = domify('<div><p data-show="file" class="file hide">Has a file</p></div>');
+  it('should remove .hidden when truthy', function(){
+    var el = domify('<div><p data-visible="file" class="file hidden">Has a file</p></div>');
     var item = { file: 'some.png' };
     var view = reactive(el, item);
-    assert('file show' == el.children[0].className);
+    assert('file visible' == el.children[0].className);
   })
 })
 
-describe('data-hide', function(){
-  it('should add .hide when truthy', function(){
-    var el = domify('<div><p data-hide="file">Has a file</p></div>');
+describe('data-hidden', function(){
+  it('should add .hidden when truthy', function(){
+    var el = domify('<div><p data-hidden="file">Has a file</p></div>');
     var item = { file: 'some.png' };
     var view = reactive(el, item);
-    assert('hide' == el.children[0].className);
+    assert('hidden' == el.children[0].className);
   })
 
-  it('should remove .show when truthy', function(){
-    var el = domify('<div><p data-hide="file" class="file show">Has a file</p></div>');
+  it('should remove .visible when truthy', function(){
+    var el = domify('<div><p data-hidden="file" class="file visible">Has a file</p></div>');
     var item = { file: 'some.png' };
     var view = reactive(el, item);
-    assert('file hide' == el.children[0].className);
+    assert('file hidden' == el.children[0].className);
   })
 })
 


### PR DESCRIPTION
for these types of class names, i think it's always better to go with the adjective version instead of the verb or noun. it lets you know they are modifiers. (makes them easily distinguishable from the noun component classes themselves, without have to do the ugly BEM stuff). that's also grounded in the fact that HTML itself uses adjective attributes for these things, like `hidden disabled etc.`

i feel like we should have a `data-class-*` binding
