### PR TITLE
fix binding to replace and update last

### DIFF
--- a/lib/bindings.js
+++ b/lib/bindings.js
@@ -65,24 +65,6 @@ module.exports = function(reactive){
     });
   });
 
-/**
- * Append child element.
- */
-
-  reactive.bind('data-append', function(el, name){
-    var other = this.value(name);
-    el.appendChild(other);
-  });
-
-/**
- * Replace element, carrying over its attributes.
- */
-
-  reactive.bind('data-replace', function(el, name){
-    var other = carry(this.value(name), el);
-    el.parentNode.replaceChild(other, el);
-  });
-
   /**
    * Show binding.
    */
@@ -158,5 +140,23 @@ module.exports = function(reactive){
         view[method](e);
       });
     });
+  });
+
+  /**
+   * Append child element.
+   */
+
+  reactive.bind('data-append', function(el, name){
+    var other = this.value(name);
+    el.appendChild(other);
+  });
+
+  /**
+   * Replace element, carrying over its attributes.
+   */
+
+  reactive.bind('data-replace', function(el, name){
+    var other = carry(this.value(name), el);
+    el.parentNode.replaceChild(other, el);
   });
 };


### PR DESCRIPTION
This fixes issues where event bindings from a child reactive instance
are actually bound to the parent since the elements are replaced
first and then bound. This does not solve the bigger replace problem
but is a nice interim solution.
