### PR TITLE
Unpatch arrays in `each` when changing arrays

### DIFF
--- a/lib/each.js
+++ b/lib/each.js
@@ -37,6 +37,8 @@ module.exports = function(el, val) {
         });
     }
 
+    var array;
+
     // bind entire new array
     function change(arr) {
 
@@ -46,7 +48,12 @@ module.exports = function(el, val) {
         });
         views = [];
 
+        // remove any old array observers
+        if (array) {
+            unpatchArray(array);
+        }
         patchArray(arr);
+        array = arr;
 
         // handle initial array
         var fragment = document.createDocumentFragment();
@@ -57,6 +64,12 @@ module.exports = function(el, val) {
             fragment.appendChild(clone);
         });
         parent.insertBefore(fragment, placeholder);
+    }
+
+    function unpatchArray(arr) {
+        delete arr.splice;
+        delete arr.push;
+        delete arr.unshift;
     }
 
     function patchArray(arr) {
@@ -138,6 +151,7 @@ module.exports = function(el, val) {
             Object.defineProperty(arr, prop, {
                 enumerable: false,
                 writable: true,
+                configurable: true,
                 value: fn
             });
         }

--- a/test/each.js
+++ b/test/each.js
@@ -62,6 +62,24 @@ describe('each', function(){
     assert.equal(el.children.length, 1);
   })
 
+  it('should not react to changes of an old array any more', function () {
+    var el = domify('<ul><li each="todos">{this}</li></ul>');
+
+    var array = ['candy'];
+    var model = { todos: array };
+    var view = reactive(el, model);
+
+    assert.equal(el.children.length, 1);
+    assert.equal(el.children[0].textContent, 'candy');
+
+    view.set('todos', ['milk']);
+    assert.equal(el.children.length, 1);
+    assert.equal(el.children[0].textContent, 'milk');
+
+    array.push('cereal');
+    assert.equal(el.children.length, 1);
+  })
+
   it('accessing properties', function(){
     var el = domify('<ul><li each="todos">{name}</li></ul>');
 


### PR DESCRIPTION
See the new test. When changing the array, modifications on the old one will still be handled.
