### PR TITLE
each should be able to handle array emitters

### DIFF
--- a/lib/each.js
+++ b/lib/each.js
@@ -67,12 +67,50 @@ module.exports = function(el, val) {
     }
 
     function unpatchArray(arr) {
-        delete arr.splice;
-        delete arr.push;
-        delete arr.unshift;
+        if (arr.hasOwnProperty('splice')) {
+            delete arr.splice;
+            delete arr.push;
+            delete arr.unshift;
+        } else if (arr.on) {
+            arr.off('add', add);
+            arr.off('remove', remove);
+            arr.off('sort', reorder);
+            arr.off('reverse', reorder);
+        }
+    }
+
+    function add(item, idx) {
+        var clone = el.cloneNode(true);
+        var child = childView(clone, item);
+        var place = placeholder;
+        if (idx < views.length) {
+            place = views[idx].el;
+        }
+        parent.insertBefore(child.el, place);
+        views.splice(idx, 0, child);
+    }
+    function remove(item, idx) {
+        views[idx].destroy();
+        views.splice(idx, 1);
+    }
+    function reorder() {
+        // sort the views according to the model position
+        views.sort(function (a, b) {
+            return array.indexOf(a.model) - array.indexOf(b.model);
+        });
+        views.forEach(function (view) {
+            parent.insertBefore(view.el, placeholder);
+        });
     }
 
     function patchArray(arr) {
+        if (arr.on) {
+            arr.on('add', add);
+            arr.on('remove', remove);
+            arr.on('sort', reorder);
+            arr.on('reverse', reorder);
+            return;
+        }
         // splice will replace the current arr.splice function
         // so that we can intercept modifications
         var old_splice = arr.splice;

--- a/test/each.js
+++ b/test/each.js
@@ -1,5 +1,6 @@
 var domify = require('domify');
 var assert = require('assert');
+var emitter = require('emitter');
 
 var reactive = require('../');
 
@@ -196,6 +197,98 @@ describe('each', function(){
     assert.equal(el.children[1].textContent, 'apples');
     assert.equal(el.children[2].textContent, 'eggs');
     assert.deepEqual(model.todos, ['milk', 'apples', 'eggs']);
+  })
+
+  it('should react to array emitters', function () {
+    var el = domify('<ul><li each="todos">{this}</li></ul>');
+
+    var model = {
+      todos: emitter([])
+    };
+
+    var view = reactive(el, model);
+
+    assert.equal(el.children.length, 0);
+
+    // add new elements
+    model.todos.push('milk');
+    model.todos.emit('add', 'milk', 0);
+    assert.equal(el.children.length, 1);
+    assert.equal(el.children[0].textContent, 'milk');
+    // remove elements
+    model.todos.pop('milk');
+    model.todos.emit('remove', 'milk', 0);
+    assert.equal(el.children.length, 0);
+
+    // insert more, and in the middle
+    model.todos.push('milk', 'apples');
+    model.todos.emit('add', 'milk', 0);
+    model.todos.emit('add', 'apples', 1);
+    assert.equal(el.children.length, 2);
+    assert.equal(el.children[0].textContent, 'milk');
+    assert.equal(el.children[1].textContent, 'apples');
+    model.todos.splice(1, 0, 'eggs');
+    model.todos.emit('add', 'eggs', 1);
+    assert.equal(el.children.length, 3);
+    assert.equal(el.children[0].textContent, 'milk');
+    assert.equal(el.children[1].textContent, 'eggs');
+    assert.equal(el.children[2].textContent, 'apples');
+
+    // and remove from the middle
+    model.todos.splice(1, 1);
+    model.todos.emit('remove', 'eggs', 1);
+    assert.equal(el.children.length, 2);
+    assert.equal(el.children[0].textContent, 'milk');
+    assert.equal(el.children[1].textContent, 'apples');
+
+    // sort the array
+    model.todos.sort();
+    model.todos.emit('sort');
+    assert.equal(el.children.length, 2);
+    assert.equal(el.children[0].textContent, 'apples');
+    assert.equal(el.children[1].textContent, 'milk');
+
+    // and reverse it
+    model.todos.reverse();
+    model.todos.emit('reverse');
+    assert.equal(el.children.length, 2);
+    assert.equal(el.children[0].textContent, 'milk');
+    assert.equal(el.children[1].textContent, 'apples');
+
+    // also test double primitives
+    model.todos.push('apples', 'apples');
+    model.todos.emit('add', 'apples', 2);
+    model.todos.emit('add', 'apples', 3);
+    model.todos.sort();
+    model.todos.emit('sort');
+    assert.equal(el.children.length, 4);
+    assert.equal(el.children[0].textContent, 'apples');
+    assert.equal(el.children[1].textContent, 'apples');
+    assert.equal(el.children[2].textContent, 'apples');
+    assert.equal(el.children[3].textContent, 'milk');
+  })
+
+  it('should correctly unbind array emitters', function () {
+    var el = domify('<ul><li each="todos">{this}</li></ul>');
+
+    var todos = emitter([]);
+    var model = {
+      todos: todos
+    };
+
+    var view = reactive(el, model);
+
+    assert.equal(el.children.length, 0);
+    view.set('todos', ['milk']);
+    assert.equal(el.children.length, 1);
+    assert.equal(el.children[0].textContent, 'milk');
+
+    todos.push('apples');
+    todos.emit('add', 'apples', 0);
+    todos.emit('sort');
+    todos.emit('reverse');
+    assert.equal(el.children.length, 1);
+    assert.equal(el.children[0].textContent, 'milk');
   })
 
   // test that items are put into the proper place in the dom


### PR DESCRIPTION
I’m a big fan of https://github.com/MatthewMueller/array, which has events builtin for any kind of array modification.
Supporting that seems a lot nicer than monkeypatching (and missing half of) the array mutator methods.
