### PR TITLE
Add nested property setting

### DIFF
--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -46,7 +46,22 @@ Adapter.prototype.unsubscribeAll = function() {
 
 Adapter.prototype.set = function(prop, val) {
   var obj = this.obj;
+  var parts = prop.split('.')
+  var part = parts.shift()
   if (!obj) return;
+
+  // split property on '.' access
+  // and dig into the object
+  while (parts.length) {
+    // create the nested property if it doesn't exist
+    if (obj[part] === undefined) {
+      obj[part] = {};
+    }
+
+    obj = obj[part];
+    part = prop = parts.shift();
+  };
+
   if ('function' == typeof obj[prop]) {
     obj[prop](val);
   }


### PR DESCRIPTION
`get()`ing nested properties using dot-notation works, so it seems logical that it should work during `set()` as well. I needed it today, so implemented it.

It behaves like a `mkdir -p`, creating objects along the path if they don't exist. The other option is to throw in error in that case. I haven't thought through the pros/cons of each.

If this is a desired feature, I'll happily add some tests & polish it up.

_EDIT: fixed a bug_
