### PR TITLE
Dont process removed nodes

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -215,6 +215,9 @@ Reactive.prototype._bind = function() {
   var bindings = self.bindings;
 
   walk(self.el, function(el, next) {
+    if (!el.parentNode) // Don't process removed nodes
+      return next()
+
     // element
     if (el.nodeType == 1) {
       var skip = false;


### PR DESCRIPTION
In IE9, the following template will error:

``` html
<div data-html="some_state_var">text to be overwritten</div>
```

The reason is, in [walk.js](https://github.com/component/reactive/blob/master/lib/walk.js), `var nodes = [].slice.call(el.childNodes)` BEFORE `process(el, next)`, which causes the `nodes` array to contain `[TextNode('text to be overwritten')]`. Once `next()` is called, however, that `TextNode` is now an orphan, having been removed through the `data-html` binding. On most browsers, this causes no problems. On IE9 however, it causes an `Invalid Argument` error when accessing `el.data` from [index.js:270](https://github.com/component/reactive/blob/master/lib/index.js#L270).

There is a larger problem here: the reactive bindings processing of deleted nodes, via `data-html` or otherwise. Two solutions exist:
- Never process deleted nodes. Test for `el.parentNode` and skip. (THIS PULL REQUEST)
- Process _new_ nodes set by `data-html` and other bindings. This has a unique side effect: `data-html` and similar bindings can now insert reactive-processed html. So this is now possible:

``` javascript
reactive('<div data-html="testhtml"></div>', { testhtml: '<div data-html="testhtml"></div>' })
```

Thus, its clear that the right answer (to me anyway) is to not process deleted nodes.
