### PR TITLE
config the scope of delegate methods

### DIFF
--- a/lib/bindings.js
+++ b/lib/bindings.js
@@ -180,7 +180,7 @@ module.exports = function(reactive){
 
         var fn = view[method];
         if (fn == null) throw new Error('method .' + method + '() missing');
-        fn.call(view, e, self.reactive);
+        fn.call(self.reactive.opt.delegateScope, e, self.reactive);
       });
     });
   });

--- a/lib/index.js
+++ b/lib/index.js
@@ -44,6 +44,7 @@ function Reactive(el, model, opt) {
   self.adapter = (opt.adapter || Adapter)(self.model);
   self.el = el;
   self.view = opt.delegate || Object.create(null);
+  self.opt.delegateScope = opt.delegateScope || self.view;
 
   self.bindings = opt.bindings || Object.create(null);
 


### PR DESCRIPTION
make the scope of delegate methods configurable.

In some cases, I need config the scope of delegate methods, but it's always point to object `delegate`.